### PR TITLE
Update for pytest 6. Tested with pytest 6.2.2

### DIFF
--- a/pytest_poo.py
+++ b/pytest_poo.py
@@ -1,7 +1,5 @@
-import pytest
 
-PILE_OF_POO = u"\U0001F4A9 "
-
+PILE_OF_POO = u"\U0001F4A9"
 
 def pytest_addoption(parser):
     group = parser.getgroup('Poo', 'Poo')
@@ -9,12 +7,11 @@ def pytest_addoption(parser):
                      action="store_true", dest="poo", default=False,
                      help="Show crappy tests.")
 
-
-def pytest_report_teststatus(report):
-    if (not pytest.config.option.poo) or ('poo' not in report.keywords) or (report.when != 'call'):
+def pytest_report_teststatus(report, config):
+    if (not config.option.poo) or ('poo' not in report.keywords) or (report.when != 'call'):
         return
 
-    if (pytest.config.option.verbose == -1 and report.passed) or pytest.config.option.verbose >= 0:
+    if (config.option.verbose == -1 and report.passed) or config.option.verbose >= 0:
         return (report.outcome, PILE_OF_POO, '%s (%s)' % (report.outcome.upper(), PILE_OF_POO))
 
 

--- a/test_pytest_poo.py
+++ b/test_pytest_poo.py
@@ -27,7 +27,7 @@ def test_fail_without_poo():
 
 
 def test_verbose_mode_no_poo(poo_testdir):
-    result = poo_testdir.runpytest('-v', '--strict')
+    result = poo_testdir.runpytest('-v', '--strict-markers')
 
     result.stdout.fnmatch_lines(['*test_success_with_poo PASSED*'])
     result.stdout.fnmatch_lines(['*test_fail_with_poo FAILED*'])
@@ -36,16 +36,16 @@ def test_verbose_mode_no_poo(poo_testdir):
 
 
 def test_verbose_mode_with_poo(poo_testdir):
-    result = poo_testdir.runpytest('-v', '--poo', '--strict')
+    result = poo_testdir.runpytest('-v', '--poo', '--strict-markers')
 
-    result.stdout.fnmatch_lines(['*test_success_with_poo PASSED (\\U0001f4a9 )*'])
-    result.stdout.fnmatch_lines(['*test_fail_with_poo FAILED (\\U0001f4a9 )*'])
+    result.stdout.fnmatch_lines(['*test_success_with_poo PASSED (\U0001f4a9)*'])
+    result.stdout.fnmatch_lines(['*test_fail_with_poo FAILED (\U0001f4a9)*'])
     result.stdout.fnmatch_lines(['*test_success_without_poo PASSED*'])
     result.stdout.fnmatch_lines(['*test_fail_without_poo FAILED*'])
 
 
 def test_quiet_mode_no_poo(poo_testdir):
-    result = poo_testdir.runpytest('-q', '--strict')
+    result = poo_testdir.runpytest('-q', '--strict-markers')
     outcome_line = result.stdout.lines[0]
 
     assert outcome_line.count('.') == 2
@@ -53,9 +53,10 @@ def test_quiet_mode_no_poo(poo_testdir):
 
 
 def test_quiet_mode_with_poo(poo_testdir, request):
-    result = poo_testdir.runpytest('-q', '--poo', '--strict')
+    result = poo_testdir.runpytest('-q', '--poo', '--strict-markers')
+    print(result.stdout)
     outcome_line = result.stdout.lines[0]
 
     assert outcome_line.count(u'.') == 1
-    assert outcome_line.count(u'\\U0001f4a9') == 1
+    assert outcome_line.count(u'\U0001f4a9') == 1
     assert outcome_line.count(u'F') == 2


### PR DESCRIPTION
Fixes issue #3

Changes:  
- remove extra space after 💩.  
   - In quiet mode, ....💩.... looks nicer than ...💩 ....
   - In verbose mode, (💩) looks nicer than (💩 )
- Change `pytest.config` to `config` and added `config` fixture where needed.
- `--strict` is now `--strict-markers`
- Removed extra backslash in tests. `'\\U0001f4a9'` -> `'\U0001f4a9'`